### PR TITLE
Add a metadata map to Svg 

### DIFF
--- a/lib/vectored/elements/element.ex
+++ b/lib/vectored/elements/element.ex
@@ -193,7 +193,7 @@ defmodule Vectored.Elements.Element do
       defelement unquote(attributes)
 
       def attrs() do
-        (__ENV__.module.__struct__() |> Map.keys()) -- [:__struct__, :content, :children, :desc, :title]
+        (__ENV__.module.__struct__() |> Map.keys()) -- [:__struct__, :content, :children, :desc, :title, :private]
       end
 
       def attributes(element) do

--- a/lib/vectored/elements/svg.ex
+++ b/lib/vectored/elements/svg.ex
@@ -21,7 +21,7 @@ defmodule Vectored.Elements.Svg do
   alias Vectored.Elements.Defs
 
   use Vectored.Elements.Element,
-    attributes: [height: nil, width: nil, preserve_aspect_ratio: nil, view_box: nil, x: nil, y: nil, defs: nil, children: []]
+    attributes: [height: nil, width: nil, preserve_aspect_ratio: nil, view_box: nil, x: nil, y: nil, defs: nil, children: [], private: %{}]
 
   @type children :: list(Vectored.Renderable.t())
   @type t :: %__MODULE__{
@@ -32,7 +32,8 @@ defmodule Vectored.Elements.Svg do
     view_box: String.t() | nil,
     preserve_aspect_ratio: String.t() | nil,
     children: children(),
-    defs: Vectored.Elements.Defs.t() | nil
+    defs: Vectored.Elements.Defs.t() | nil,
+    private: map()
   }
 
   @spec new() :: t()
@@ -84,6 +85,14 @@ defmodule Vectored.Elements.Svg do
   end
   def append_defs(%__MODULE__{} = svg, element) do
     append_defs(svg, List.wrap(element))
+  end
+
+  def put_private(%__MODULE__{} = svg, key, value) do
+    %{svg | private: Map.put(svg.private, key, value)}
+  end
+
+  def delete_private(%__MODULE__{} = svg, key) do
+    %{svg | private: Map.delete(svg.private, key)}
   end
 
   defimpl Vectored.Renderable do

--- a/lib/vectored/elements/text.ex
+++ b/lib/vectored/elements/text.ex
@@ -48,6 +48,11 @@ defmodule Vectored.Elements.Text do
     %__MODULE__{x: x, y: y, content: content}
   end
 
+  @spec new(String.t()) :: t()
+  def new(content) do
+    %__MODULE__{content: content}
+  end
+
   @doc """
   Set the x and y properties of the Circle to set its location
   """

--- a/test/vectored/elements/text_test.exs
+++ b/test/vectored/elements/text_test.exs
@@ -4,13 +4,24 @@ defmodule Vectored.Elements.TextTest do
   alias Vectored.Renderable
 
   test "is renderable" do
-    assert {:text, attrs, _content} =
-      Text.new(1, 1, "Test")
-      |> Renderable.to_svg()
+    assert {:text, attrs, _} =
+             Text.new(1, 1, "Test")
+             |> Renderable.to_svg()
 
     assert [{:x, 1}, {:y, 1}] ==
-      attrs
-      |> Enum.sort_by(& elem(&1, 0))
+             attrs
+             |> Enum.sort_by(&elem(&1, 0))
+
+  end
+
+  test "is renderable w/o location" do
+    assert {:text, attrs, _} =
+             Text.new("Test")
+             |> Renderable.to_svg()
+
+    assert [{:x, 0}, {:y, 0}] ==
+             attrs
+             |> Enum.sort_by(&elem(&1, 0))
 
   end
 end

--- a/test/vectored_test.exs
+++ b/test/vectored_test.exs
@@ -64,7 +64,7 @@ defmodule VectoredTest do
     assert path_attrs == "M 10,10 L 90,90 V 10 H 50"
   end
 
-  test "cam render desc and title" do
+  test "can render desc and title" do
     assert {:circle, _attrs, children} =
       Circle.new(10)
       |> Circle.with_description("I'm a circle")
@@ -74,5 +74,24 @@ defmodule VectoredTest do
     assert [{:desc, [], _}, {:title, [], _}] =
       children
       |> Enum.sort_by(& elem(&1, 0))
+  end
+
+  describe "private data" do
+    test "empty state, does not get rendered" do
+      svg = Svg.new()
+      assert svg.private == %{}
+      assert Vectored.to_svg(svg) == {:svg, [], []}
+    end
+
+    test "can have privatedata, but doesn't render it" do
+      svg = 
+        Svg.new()
+        |> Svg.with_private(%{a: 1, b: 2})
+        |> Svg.put_private(:c, 3)
+        |> Svg.delete_private(:b)
+  
+      assert %{a: 1, c: 3} = svg.private
+      assert Vectored.to_svg(svg) == {:svg, [], []}
+    end
   end
 end


### PR DESCRIPTION
Allows metadata to be added to the Svg and be available as it is built up through a pipeline.
Examples would be things like user options that change the diagram, field dimensions, color themes, etc. 
