### PR TITLE
Add community standards docs and changelog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps or code to reproduce the behavior:
+
+```elixir
+# Example code that triggers the bug
+```
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened. Include any error messages or stack traces.
+
+**Environment**
+- Elixir version:
+- OTP version:
+- Vectored version:
+
+**Additional context**
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem?**
+A clear description of the problem. Example: "I'm always frustrated when..."
+
+**Describe the solution you'd like**
+What you want to happen.
+
+**Describe alternatives you've considered**
+Any alternative solutions or features you've considered.
+
+**Additional context**
+Any other context, code examples, or SVG use cases.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Description
+
+Brief description of the changes.
+
+## Motivation
+
+Why is this change needed? Link any related issues.
+
+Fixes #
+
+## Changes
+
+- 
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] `mix test` passes
+- [ ] `mix format --check-formatted` passes
+- [ ] `mix credo --strict` passes
+- [ ] Documentation updated (if applicable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Added Credo and fixed map_join optimization warnings
+- Documentation improvements and typo fixes
+- Updated mix.exs for Hex publishing
+
+## [0.3.4] - 2025-09-22
+
+### Added
+
+- Support for custom data attributes
+
+### Changed
+
+- Updated dependencies
+- Code formatting pass
+
+## [0.3.3] - 2025-09-08
+
+### Added
+
+- Private data map on SVG struct (using `private` to avoid confusion with SVG meta tag)
+- CI test runner with badge
+
+### Changed
+
+- Allow `Text.new/0` without requiring x/y coordinates
+
+## [0.3.2] - 2024-07-22
+
+### Fixed
+
+- Allow `Use` to take a title and other common children ([#2](https://github.com/geofflane/vectored/issues/2))
+
+## [0.3.1] - 2024-07-18
+
+### Fixed
+
+- Rectangle rendering
+
+## [0.3.0] - 2024-06-21
+
+### Added
+
+- Polygon support
+
+## [0.2.0] - 2024-06-20
+
+### Added
+
+- Common elements: title, desc, and better defs handling
+- Basic transform support
+- Macro-generated common attributes and setter functions for every property
+- Documentation, specs, and typespecs
+- License info in README
+
+### Fixed
+
+- Element casing
+- Size handling
+
+## [0.1.0] - 2024-06-18
+
+### Added
+
+- Initial release
+- Core SVG struct and rendering
+- Basic elements: circle, rect, line, ellipse, text, image
+- Path support with builder API
+- Polyline support
+- Markers
+- Defs and Use elements
+- xmlns handling
+
+[Unreleased]: https://github.com/geofflane/vectored/compare/0.3.4...HEAD
+[0.3.4]: https://github.com/geofflane/vectored/compare/0.3.3...0.3.4
+[0.3.3]: https://github.com/geofflane/vectored/compare/0.3.2...0.3.3
+[0.3.2]: https://github.com/geofflane/vectored/compare/0.3.1...0.3.2
+[0.3.1]: https://github.com/geofflane/vectored/compare/0.3.0...0.3.1
+[0.3.0]: https://github.com/geofflane/vectored/compare/0.2.0...0.3.0
+[0.2.0]: https://github.com/geofflane/vectored/compare/0.1.0...0.2.0
+[0.1.0]: https://github.com/geofflane/vectored/releases/tag/0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at geoff@zorched.net. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to Vectored
+
+Thanks for your interest in contributing! Here's how to get started.
+
+## Getting Started
+
+1. [Fork the repo](https://github.com/geofflane/vectored/fork) and clone your fork
+2. Create a feature branch: `git checkout -b my-feature`
+3. Install dependencies: `mix deps.get`
+
+## Development
+
+Run the test suite:
+
+```bash
+mix test
+```
+
+Before submitting, please make sure your code passes:
+
+```bash
+mix format --check-formatted
+mix credo --strict
+mix dialyzer
+```
+
+## Submitting Changes
+
+1. Commit your changes with a clear message
+2. Push to your fork: `git push origin my-feature`
+3. [Open a pull request](https://github.com/geofflane/vectored/compare) against `main`
+
+Please include:
+
+- A description of what changed and why
+- Tests for new functionality
+- Updated documentation if applicable
+
+## Code Style
+
+This project uses `mix format` for consistent formatting. The `.formatter.exs` file in the repo root defines the rules.
+
+## Questions?
+
+Open an issue — happy to help!


### PR DESCRIPTION
Adds recommended GitHub community standards and a changelog built from git history.

## Added
- **CHANGELOG.md** — [Keep a Changelog](https://keepachangelog.com/) format, covering all releases (0.1.0 through 0.3.4) plus unreleased changes
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **CONTRIBUTING.md** — Development workflow (fork, branch, test, format, credo, dialyzer, PR)
- **Issue templates** — Bug report and feature request
- **PR template** — Description, motivation, changes, and checklist